### PR TITLE
Faster cmake target dependencies

### DIFF
--- a/cmake/PYB11Generator.cmake
+++ b/cmake/PYB11Generator.cmake
@@ -193,42 +193,16 @@ macro(PYB11_GENERATE_BINDINGS target_name module_name PYB11_SOURCE)
   # Extract the name of PYB11 generating source code without the .py extension
   string(REGEX REPLACE "\\.[^.]*$" "" pyb11_module ${PYB11_SOURCE})
 
-  # Generating python stamp files to detect changes in PYB11_SOURCE and
-  # its included modules
-  if(EXISTS ${PYTHON_EXE})
-    # Python must exist to generate at config time
-    if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${module_name}_stamp.cmake")
-      # Generate stamp files at config time
-      execute_process(COMMAND env PYTHONPATH=\"${PYTHON_ENV}\"
-                      ${PYTHON_EXE} ${PYB11GENERATOR_ROOT_DIR}/cmake/moduleCheck.py 
-                      ${module_name}
-                      ${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_SOURCE}
-                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                      )
-    endif()
-
-    # Include list of dependent python files
-    include(${CMAKE_CURRENT_BINARY_DIR}/${module_name}_stamp.cmake)
-  endif()
-
-  # Always regenerate the stamp files at build time. Any change in the stamp file
+  # Always generate cpp files at build time. Any change in the cpp file
   # will trigger a rebuild of the target pyb11 module
-  add_custom_target(${module_name}_stamp ALL
-                    COMMAND env PYTHONPATH=\"${PYTHON_ENV}\"
-                    ${PYTHON_EXE} ${PYB11GENERATOR_ROOT_DIR}/cmake/moduleCheck.py
-                    ${pyb11_module}
-                    ${CMAKE_CURRENT_SOURCE_DIR}/${PYB11_SOURCE}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                    )
-
-  # Generate the actual pyb11 module cpp source file
-  add_custom_command(OUTPUT ${PYB11_GENERATED_SOURCE}
-                     COMMAND env PYTHONPATH=\"${PYTHON_ENV}\"
-                     ${PYTHON_EXE} -c
-                     'from PYB11Generator import * \; 
-                     import ${pyb11_module} \;
-                     PYB11generateModule(${pyb11_module}, \"${module_name}\") '
-                     DEPENDS ${module_name}_stamp ${${target_name}_DEPENDS} ${PYB11_SOURCE}
-                     )
+  add_custom_target(
+    ${module_name}_src ALL
+    COMMAND env PYTHONPATH=\"${PYTHON_ENV}\"
+    ${PYTHON_EXE} ${PYB11GENERATOR_ROOT_DIR}/cmake/generate_cpp.py
+    ${pyb11_module}
+    ${module_name}
+    BYPRODUCTS ${PYB11_GENERATED_SOURCE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
 
 endmacro()

--- a/cmake/generate_cpp.py
+++ b/cmake/generate_cpp.py
@@ -1,0 +1,30 @@
+import sys
+import os
+import filecmp
+
+pyb11_mod_name = sys.argv[1]
+mod_name = sys.argv[2]
+tmp_name = mod_name + "_tmp"
+
+code = """
+from PYB11Generator import *
+import ${pyb11_module}
+PYB11generateModule(${pyb11_module}, \"${tmp_name}\")
+"""
+code = code.replace("${pyb11_module}", pyb11_mod_name)
+code = code.replace("${tmp_name}", tmp_name)
+
+exec(code)
+
+current_src = mod_name + ".cc"
+tmp_src = mod_name + "_tmp.cc"
+
+if (os.path.isfile(current_src)):
+  if (not filecmp.cmp(current_src, tmp_src)):
+    os.rename(tmp_src, current_src)
+  else:
+    os.remove(tmp_src)
+else:
+  os.rename(tmp_src, current_src)
+
+


### PR DESCRIPTION
Python3 `modulefinder` is considerably slower than the Python2 implementation. This PR attempts to change how we define a cmake target dependency when compiling pyb11 modules.

This PR removes the generation of `_stamp` files in favor of regenerating the `.cpp` source files on every build, updating the generated `.cpp` file whenever there is a change, there are some tradeoffs for this approach:

Pros:
- Faster config time, we no longer need to run `moduleCheck.py` at config time for each package.
- Faster build time dependency check. We previously ran `moduleCheck.py` on every build to check if the list of imported packages to a `*PYB11.py` file had been changed. Now `generate_cpp.py` runs each time which is faster.
- Only recompile when the final output `.cpp` file is changed. Trivial changes in pyb11generator files such as whitespace or formatting won't trigger a recompile of the final `.cpp` file.

Cons:
- Trivial changes in pyb11generator `.py` files that have other side effects will not trigger a rebuild of the final `.cpp` file.