### PR TITLE
Added support for python3.11+

### DIFF
--- a/PYB11Generator/PYB11function.py
+++ b/PYB11Generator/PYB11function.py
@@ -116,7 +116,7 @@ def PYB11generateFunction(meth, methattrs, ssout):
     ss = fs.write
 
     # Arguments
-    stuff = inspect.getargspec(meth)
+    stuff = inspect.getfullargspec(meth)
     nargs = len(stuff.args)
     argNames = stuff.args
     argTypes, argDefaults = [], []

--- a/PYB11Generator/PYB11utils.py
+++ b/PYB11Generator/PYB11utils.py
@@ -237,7 +237,7 @@ def PYB11functions(modobj):
 # Return (argType, argName, <default_value>)
 #-------------------------------------------------------------------------------
 def PYB11parseArgs(meth):
-    stuff = inspect.getargspec(meth)
+    stuff = inspect.getfullargspec(meth)
     result = []
     if stuff.defaults:
         nargs = len(stuff.defaults)


### PR DESCRIPTION
Adds support for python3.11, while maintaining support for older versions of python3 (though I only tested with python3.10)
Updated pybind11 submodule 
Changed instances of inspect.getargspec to getfullargspec (getargspec was deprecated in 3.0 and  removed in 3.11)