### PR TITLE
Virtual Env Support

### DIFF
--- a/cmake/PYB11Generator.cmake
+++ b/cmake/PYB11Generator.cmake
@@ -210,7 +210,6 @@ macro(PYB11_GENERATE_BINDINGS package_name module_name PYB11_SOURCE)
   if (DEFINED ${package_name}_VIRTUAL_ENV)
     get_target_property(ACTIVATE_VENV_CMD ${${package_name}_VIRTUAL_ENV} ACTIVATE_VENV)
     get_target_property(PYTHON_EXE ${${package_name}_VIRTUAL_ENV} EXECUTABLE)
-    message("check")
   endif()
 
   # Always generate cpp files at build time. Any change in the cpp file

--- a/cmake/PYB11Generator.cmake
+++ b/cmake/PYB11Generator.cmake
@@ -209,6 +209,7 @@ macro(PYB11_GENERATE_BINDINGS package_name module_name PYB11_SOURCE)
 
   if (DEFINED ${package_name}_VIRTUAL_ENV)
     get_target_property(ACTIVATE_VENV_CMD ${${package_name}_VIRTUAL_ENV} ACTIVATE_VENV)
+    list(APPEND ACTIVATE_VENV_CMD &&)
     get_target_property(PYTHON_EXE ${${package_name}_VIRTUAL_ENV} EXECUTABLE)
   endif()
 

--- a/cmake/PYB11Generator.cmake
+++ b/cmake/PYB11Generator.cmake
@@ -199,16 +199,16 @@ macro(PYB11_GENERATE_BINDINGS package_name module_name PYB11_SOURCE)
   # Extract the name of PYB11 generating source code without the .py extension
   string(REGEX REPLACE "\\.[^.]*$" "" pyb11_module ${PYB11_SOURCE})
 
+  get_target_property(VENV python_build_env ACTIVATE_VENV)
+
   # Always generate cpp files at build time. Any change in the cpp file
   # will trigger a rebuild of the target pyb11 module
   add_custom_target(
     ${module_name}_src ALL
-    COMMAND env PYTHONPATH=\"${PYTHON_ENV}\"
-    ${PYTHON_EXE} ${PYB11GENERATOR_ROOT_DIR}/cmake/generate_cpp.py
-    ${pyb11_module}
-    ${module_name}
+    COMMAND ${VENV} && env PYTHONPATH="${PYTHON_ENV}" ${PYTHON_EXE} ${PYB11GENERATOR_ROOT_DIR}/cmake/generate_cpp.py ${pyb11_module} ${module_name}
     BYPRODUCTS ${PYB11_GENERATED_SOURCE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS python_build_env
     )
 
 endmacro()


### PR DESCRIPTION
This adds the option to use a python virtual environment to execute `PYB11Generator_add_module` through the argument `VIRTUAL_ENV`. 

If `VIRTUAL_ENV` is not passed `PYB11Generator_add_module` does not change behavior.