### PR TITLE
Adding documentation and an example of how to bind C++ code using the Curiously Recurring Template Pattern

### DIFF
--- a/PYB11Generator/PYB11class.py
+++ b/PYB11Generator/PYB11class.py
@@ -49,7 +49,7 @@ class PYB11TemplateClass:
         self.template_parameters = {}
         klassattrs = PYB11attrs(self.klass_template)
         if isinstance(template_parameters, str):
-            assert len(klassattrs["template"]) == 1
+            assert len(klassattrs["template"]) == 1, f"Bad template parameters: {klass_template} : {klassattrs['template']}"
             self.template_parameters[klassattrs["template"][0].split()[1]] = template_parameters
         elif isinstance(template_parameters, tuple):
             assert len(klassattrs["template"]) == len(template_parameters)

--- a/docs/complications.rst
+++ b/docs/complications.rst
@@ -168,6 +168,77 @@ In this case the descendant ``B`` class inherits from ``A``, but specializes one
 
   B_double_int = PYB11TemplateClass(B, template_parameters=("double", "int")
 
+----------------------------------------------
+Using the Curiously Recurring Template Pattern
+----------------------------------------------
+
+The Curiously Recurring Template Pattern (`CRTP <https://en.cppreference.com/w/cpp/language/crtp.html>`_) is a method of implementing static polymorphism in C++.  Binding classes in PYB11Generator using this pattern is another example of the above cases where the template pattern is changed between base and derived classes, but can still be confusing.  An simplified example in C++ might look like:
+
+.. code-block:: cpp
+
+  #include <cstdio>
+
+  template<typename Descendant, typename Value>
+  class A {
+  public:
+    A()                                                   { printf("A::A()\\n"); }
+    virtual ~A()                                          { printf("A::~A()\\n"); }
+    Value func() const                                    { auto x = asDescendant().func(); printf("A::func() : %f\\n", x); return x; }
+    Descendant& asDescendant() const                      { return static_cast<Descendant&>(const_cast<A<Descendant, Value>&>(*this)); }
+  };
+
+  template<typename Value>
+  class B: public A<B<Value>, Value> {
+  public:
+    B(const Value x): A<B, Value>(), mval(x)              { printf("B::B(%f)\\n", x); }
+    virtual ~B()                                          { printf("B::~B()\\n"); }
+    Value func() const                                    { printf("B::func()\\n"); return mval; }
+    B() = delete;
+  private:
+    Value mval;
+  };
+
+  template<typename Value>
+  class C: public B<Value> {
+  public:
+    C(const Value x): B<Value>(x)                         { printf("C::C(%f)\\n", x); }
+    virtual ~C()                                          { printf("C::~C()\\n"); }
+    C() = delete;
+  };
+
+This example can be wrapped for Python using PYB11Generator using the ``@PYB11template_dict`` decorator to augment the template parameters of descendant types (class ``B`` in this example) with the needed ``Descendant`` template argument::
+
+  @PYB11template("Descendant", "Value")
+  class A:
+
+      def pyinit(self):
+          return
+
+      @PYB11const
+      def func(self):
+          return "%(Value)s"
+
+  @PYB11template("Value")
+  @PYB11template_dict({"Descendant" : "B<%(Value)s>"}) # <--- specify the template parameter substitutions
+  class B(A):
+
+      def pyinit(self, x = "%(Value)s"):
+          return
+
+      @PYB11const
+      def func(self):
+          return "%(Value)s"
+
+  @PYB11template("Value")
+  class C(B):
+
+      def pyinit(self, x = "%(Value)s"):
+          return
+
+  ABdouble = PYB11TemplateClass(A, template_parameters=("B<double>", "double"))
+  Bdouble = PYB11TemplateClass(B, template_parameters="double")
+  Cdouble = PYB11TemplateClass(C, template_parameters="double")
+
 --------------------------------
 Binding ``constexpr`` statements
 --------------------------------

--- a/tests/inheritance/CMakeLists.txt
+++ b/tests/inheritance/CMakeLists.txt
@@ -1,4 +1,4 @@
-PYB11Generator_add_module(change_templates INSTALL ${CMAKE_INSTALL_PREFIX}/tests/inheritance)
-PYB11Generator_add_module(inherit_base_virtual_methods INSTALL ${CMAKE_INSTALL_PREFIX}/tests/inheritance)
+PYB11Generator_add_module(change_templates                  INSTALL ${CMAKE_INSTALL_PREFIX}/tests/inheritance)
+PYB11Generator_add_module(inherit_base_virtual_methods      INSTALL ${CMAKE_INSTALL_PREFIX}/tests/inheritance)
 PYB11Generator_add_module(nontemplate_inherit_from_template INSTALL ${CMAKE_INSTALL_PREFIX}/tests/inheritance)
-
+PYB11Generator_add_module(CRTP                              INSTALL ${CMAKE_INSTALL_PREFIX}/tests/inheritance)

--- a/tests/inheritance/CRTP_PYB11.py
+++ b/tests/inheritance/CRTP_PYB11.py
@@ -1,0 +1,65 @@
+from PYB11Generator import *
+
+PYB11preamble = """
+#include <cstdio>
+
+template<typename Descendant, typename Value>
+class A {
+public:
+  A()                                                   { printf("A::A()\\n"); }
+  virtual ~A()                                          { printf("A::~A()\\n"); }
+  Value func() const                                    { auto x = asDescendant().func(); printf("A::func() : %f\\n", x); return x; }
+  Descendant& asDescendant() const                      { return static_cast<Descendant&>(const_cast<A<Descendant, Value>&>(*this)); }
+};
+
+template<typename Value>
+class B: public A<B<Value>, Value> {
+public:
+  B(const Value x): A<B, Value>(), mval(x)              { printf("B::B(%f)\\n", x); }
+  virtual ~B()                                          { printf("B::~B()\\n"); }
+  Value func() const                                    { printf("B::func()\\n"); return mval; }
+  B() = delete;
+private:
+  Value mval;
+};
+
+template<typename Value>
+class C: public B<Value> {
+public:
+  C(const Value x): B<Value>(x)                         { printf("C::C(%f)\\n", x); }
+  virtual ~C()                                          { printf("C::~C()\\n"); }
+  C() = delete;
+};
+
+"""
+
+@PYB11template("Descendant", "Value")
+class A:
+
+    def pyinit(self):
+        return
+
+    @PYB11const
+    def func(self):
+        return "%(Value)s"
+
+@PYB11template("Value")
+@PYB11template_dict({"Descendant" : "B<%(Value)s>"}) # <--- specify the template parameter substitutions
+class B(A):
+
+    def pyinit(self, x = "%(Value)s"):
+        return
+
+    @PYB11const
+    def func(self):
+        return "%(Value)s"
+
+@PYB11template("Value")
+class C(B):
+
+    def pyinit(self, x = "%(Value)s"):
+        return
+
+ABdouble = PYB11TemplateClass(A, template_parameters=("B<double>", "double"))
+Bdouble = PYB11TemplateClass(B, template_parameters="double")
+Cdouble = PYB11TemplateClass(C, template_parameters="double")


### PR DESCRIPTION
At first I was worried we had a bug/oversight in PYB11Generator, but it is possible to handle examples using the CRTP with the existing PYB11Generator syntax.  This merge includes a new example/test of this pattern, and an extension of the documentation showing how this is done.
